### PR TITLE
Fix add to cart bug for variations

### DIFF
--- a/woocommerce-max-quantity.php
+++ b/woocommerce-max-quantity.php
@@ -154,11 +154,12 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		}
 
 		if ( $variation->managing_stock() && ! $variation->backorders_allowed() ) {
+			$stock = $variation->get_stock_quantity();
 
 			// Limit our max by the available stock, if stock is lower
 
 			// Set to lessor of stock qty or max allowed
-			$args['max_qty'] = min( $max, $args['max_qty'] );
+			$args['max_qty'] = min( $stock, $args['max_qty'] );
 
 		}
 


### PR DESCRIPTION
Original would not allow adding variations to cart when limit over 1 was entered into the parent product’s max qty field.

This patch makes variations act the same way as simple products with respect to calculating the limit taking into account the stock on hand.